### PR TITLE
Adding ops file for removing logstash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 deploy-elastic-stack.sh
 logstash.conf
+.DS_Store
+

--- a/ops-files/remove-logstash.yml
+++ b/ops-files/remove-logstash.yml
@@ -1,0 +1,2 @@
+- type: remove
+  path: /instance_groups/name=logstash


### PR DESCRIPTION
Thank you very much for providing the elastic stack bosh releases!

Some deployments might not require logstash for their Elasticsearch needs, so this pull request adds an ops file for removing logstash.

This allows creation of a simple Elasticsearch cluster with Kibana like this for example:

```
bosh -d elastic-stack deploy elastic-stack.yml \
     -l versions.yml \
     -o ops-files/vm_types.yml \
     -o ops-files/disk_types.yml \
     -o ops-files/instances.yml \
     -o ops-files/networks.yml \
     -o ops-files/azs.yml \
     -o ops-files/remove-logstash.yml \
     -v elasticsearch_master_instances=3 \
     -v elasticsearch_master_vm_type=default \
     -v elasticsearch_master_disk_type=default \
     -v elasticsearch_master_network=default \
     -v elasticsearch_master_azs="[z1, z2, z3]" \
     -v kibana_instances=1 \
     -v kibana_vm_type=default \
     -v kibana_network=default \
     -v kibana_azs="[z1, z2, z3]" \
     --no-redact
```