### PR TITLE
Adding ops file for enabling Elasticsearch & Logstash monitoring

### DIFF
--- a/ops-files/elasticsearch-enable-monitoring.yml
+++ b/ops-files/elasticsearch-enable-monitoring.yml
@@ -1,0 +1,9 @@
+- type: replace
+  path: /instance_groups/name=elasticsearch-master/jobs/name=elasticsearch/properties/xpack?/monitoring?
+  value:
+    collection:
+      enabled: true
+    exporters:
+      bosh_es_local:
+        type: local
+        use_ingest: false

--- a/ops-files/logstash-enable-monitoring-add-ssl.yml
+++ b/ops-files/logstash-enable-monitoring-add-ssl.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=logstash/jobs/name=logstash/properties/xpack?/monitoring?/elasticsearch?/ssl?/ca?
+  value: ((nginx_ca.ca))
+
+- type: replace
+  path: /instance_groups/name=logstash/jobs/name=logstash/properties/xpack?/monitoring?/elasticsearch?/ssl?/verification_mode?
+  value: none

--- a/ops-files/logstash-enable-monitoring.yml
+++ b/ops-files/logstash-enable-monitoring.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=logstash/jobs/name=logstash/properties/xpack?/monitoring?/enabled?
+  value: true


### PR DESCRIPTION
Ops-file for enabling X-Pack Monitoring.

BOSH Release commits(spec) are:
https://github.com/bosh-elastic-stack/elasticsearch-boshrelease/pull/13
https://github.com/bosh-elastic-stack/logstash-boshrelease/pull/5

