### PR TITLE
Increase proxy_buffer_size on Kibana Nginx for handling long URL

### DIFF
--- a/ops-files/kibana-https-and-basic-auth.yml
+++ b/ops-files/kibana-https-and-basic-auth.yml
@@ -53,6 +53,7 @@
               proxy_http_version 1.1;
               proxy_set_header Connection "";
               proxy_buffering off;
+              proxy_buffer_size 8k;
               client_max_body_size 0;
               proxy_read_timeout 36000s;
               proxy_redirect off;


### PR DESCRIPTION
## Issue
When filtering with many queries on Kibana, Nginx returns 502 because of long URL.
This issue will be only occured when using **Short URL** for sharing.

## Fix
Increase `proxy_buffer_size` (default: 4k) on Kibana Nginx. (This PR)